### PR TITLE
Update Object.getOwnPropertyNames

### DIFF
--- a/polyfills/Object.getOwnPropertyNames/polyfill.js
+++ b/polyfills/Object.getOwnPropertyNames/polyfill.js
@@ -6,7 +6,9 @@ Object.getOwnPropertyNames = function getOwnPropertyNames(object) {
 	var buffer = [], key;
 
 	for (key in object) {
-		buffer.push(key);
+		if (object.hasOwnProperty(key)) {
+			buffer.push(key);
+		}
 	}
 
 	return buffer;


### PR DESCRIPTION
`Object.getOwnPropertyNames` should only return properties for the specified object, not its ancestors. However, `for .. in`, when used by itself, gets all properties including from objects on the prototype chain. Added `hasOwnProperty` to prevent this.
